### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -65,10 +65,17 @@ jobs:
   build-python-wheels:
     env:
       CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* pp* *i686 *win32"
+      CIBW_ARCHS_LINUX: ${{matrix.arch}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [x86_64, aarch64]
+        exclude:
+          - os: macos-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
@@ -76,6 +83,9 @@ jobs:
         name: Setup python
         with:
           python-version: '3.8'
+      - uses: docker/setup-qemu-action@v1
+        if: ${{ matrix.arch == 'aarch64' }}
+        name: Set up QEMU
       - name: Install bump2version
         run: pip install bump2version
       - name: Install cibuildwheel


### PR DESCRIPTION
Add linux aarch64 wheel build support.
Related to https://github.com/fornwall/advent-of-code/issues/10 @fornwall Could you please review this PR?