### PR TITLE
2015 day06: resolve action once per line and iterate row-major

### DIFF
--- a/crates/core/src/year2015/day06.rs
+++ b/crates/core/src/year2015/day06.rs
@@ -1,5 +1,12 @@
 use crate::input::{Input, Part};
 
+#[derive(Clone, Copy)]
+enum Action {
+    On,
+    Off,
+    Toggle,
+}
+
 pub fn solve(input: &Input) -> Result<usize, String> {
     fn parse_tuple(tuple: &str) -> Option<(u16, u16)> {
         tuple.split_once(',').and_then(|(first, second)| {
@@ -10,31 +17,31 @@ pub fn solve(input: &Input) -> Result<usize, String> {
     let mut grid = vec![0_u8; 1_000_000].into_boxed_slice();
     for line in input.text.lines() {
         let words = line.split(' ').collect::<Vec<&str>>();
-        let is_toggle = words[0] == "toggle";
-        let expected_word_count = if is_toggle { 4 } else { 5 };
-        if words.len() != expected_word_count {
-            return Err("Invalid input".to_string());
-        }
 
-        let (from, to) = if is_toggle {
-            (words[1], words[3])
-        } else {
-            (words[2], words[4])
+        // Resolve the action once per line instead of comparing command
+        // strings for every one of the up to a million cells in the region.
+        let (action, from, to) = match words.as_slice() {
+            ["turn", "on", from, "through", to] => (Action::On, from, to),
+            ["turn", "off", from, "through", to] => (Action::Off, from, to),
+            ["toggle", from, "through", to] => (Action::Toggle, from, to),
+            _ => return Err("Invalid input".to_string()),
         };
 
         let (from_x, from_y) = parse_tuple(from).ok_or("Invalid input")?;
         let (to_x, to_y) = parse_tuple(to).ok_or("Invalid input")?;
 
-        for x in from_x..=to_x {
-            for y in from_y..=to_y {
-                let index = x as usize + y as usize * 1000;
-                grid[index] = match (words[1], input.part) {
-                    ("on", Part::One) => 1,
-                    ("on", Part::Two) => grid[index] + 1,
-                    ("off", Part::One) => 0,
-                    ("off", Part::Two) => grid[index] - u8::from(grid[index] != 0),
-                    (_, Part::One) => u8::from(grid[index] == 0),
-                    (_, Part::Two) => grid[index] + 2,
+        // Iterate row-major so consecutive indices are contiguous in memory.
+        for y in from_y..=to_y {
+            let row_offset = y as usize * 1000;
+            for x in from_x..=to_x {
+                let cell = &mut grid[row_offset + x as usize];
+                *cell = match (input.part, action) {
+                    (Part::One, Action::On) => 1,
+                    (Part::One, Action::Off) => 0,
+                    (Part::One, Action::Toggle) => u8::from(*cell == 0),
+                    (Part::Two, Action::On) => *cell + 1,
+                    (Part::Two, Action::Off) => cell.saturating_sub(1),
+                    (Part::Two, Action::Toggle) => *cell + 2,
                 };
             }
         }


### PR DESCRIPTION
Refactors the year 2015 day 6 solution for clarity and speed.

- **Parse the command once per line** into an `Action` enum via slice pattern matching, instead of re-comparing command strings (`words[1]`, `"on"`/`"off"`) inside the inner loop for each of the up to a million cells in a region. Pattern matching also replaces the manual word-count validation.
- **Iterate row-major** (`y` outer, `x` inner) so consecutive grid indices are contiguous in memory.
- Use `saturating_sub(1)` for the part-two "turn off" case instead of the `grid[index] - u8::from(...)` dance.

No behavior change — the existing `year2015::day06` test passes, and clippy is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNMyhEorYikrXe9HcZ5pMW