### PR TITLE
Fix test-python rustup conflict by dropping redundant toolchain step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
         python-version: ['3.12', '3.x']
     steps:
     - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@stable
+    # No explicit toolchain setup: the build reads rust-toolchain and installs
+    # the pinned toolchain itself. Adding dtolnay/rust-toolchain@stable on top
+    # caused a rustup component conflict (clippy / bin/cargo-clippy) when the
+    # pinned toolchain was then installed during the build.
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
The `test-python` job set up a toolchain with `dtolnay/rust-toolchain@stable`, then built the Rust extension via `make test-python` (`pip install -e .`). The build reads the repo's `rust-toolchain` file (channel `1.96.0`, components `clippy` + `rustfmt`) and installs that toolchain, which collided with the just-installed stable toolchain:

```
info: removing previous version of component clippy
error: failed to install component: 'clippy-preview-x86_64-unknown-linux-gnu',
       detected conflict: 'bin/cargo-clippy'
error: can't find Rust compiler
```

Since the build installs the pinned toolchain itself via `rust-toolchain`, the action step is redundant. Dropping it removes the conflict (rustup is preinstalled on the runner image, so `cargo`/`rustup` are available to honor the toolchain file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)